### PR TITLE
Use python 3.9 to fix stacker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:latest
+FROM python:3.9-alpine
 LABEL maintainer="isaac.gittins@amaysim.com.au"
 
-RUN apk --no-cache add python3 bash git jq gettext make nodejs npm py3-pip curl groff openssl
+RUN apk update && apk upgrade && apk --no-cache add bash git jq gettext make nodejs npm curl groff openssl
 
 RUN pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir wheel && \


### PR DESCRIPTION
collections.Mapping has been removed from Python 3.10 and makes stacker
breaks.
From https://docs.python.org/release/3.10.2/whatsnew/changelog.html#python-3-9-0-alpha-4

> Aliases to ABC like collections.Mapping are kept in Python 3.9 to ease
> transition from Python 2.7, but will be removed in Python 3.10.

To fix it, the image is now based on python:3.9-alpine which will
include futher 3.9 releases. The image weight is similar to previous
images.