### PR TITLE
DOPE-7670 : Updated cfn-lint version to support CloudfrontDistribution Attr from UserPoolDomaon Resource Output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && apk upgrade && apk --no-cache add bash git jq gettext make nod
 
 RUN pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir wheel && \
-    pip3 install --no-cache-dir cfn-lint==0.63.0 cfn-flip yamllint stacker awscli python-dateutil==2.8.0 jinja2 pyyaml shellcheck-py
+    pip3 install --no-cache-dir cfn-lint==0.82.2 cfn-flip yamllint stacker awscli python-dateutil==2.8.0 jinja2 pyyaml shellcheck-py
 
 # Disable until CFN Defs Spec >= 86 resolves AWS::RDS::DBCluster Attributes spec issue
 # RUN cfn-lint -u


### PR DESCRIPTION
This is resolve the issue in E1010 to allow the linting support for checking the resource output CloudFrontDistribution from the AWS::Cognito::UserPoolDomain resource. 