### PR TITLE
Pin-cfn-lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@ RUN dnf -y upgrade && \
     dnf -y --allowerasing install diffutils python3-pip python3-setuptools python3-wheel git jq gettext make nodejs npm curl groff openssl wget tar gzip findutils awscli-2 && \
     dnf clean all
 
-RUN pip3 install --no-cache-dir --upgrade cfn-lint cfn-flip yamllint stacker jinja2 pyyaml shellcheck-py pylint
-
-RUN cfn-lint -u
+RUN pip3 install --no-cache-dir --upgrade cfn-lint==0.87.6 cfn-flip yamllint stacker jinja2 pyyaml shellcheck-py pylint
 
 RUN mkdir -p /tmp/yarn && \
   mkdir -p /opt/yarn/dist && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazonlinux:2023
-LABEL maintainer="isaac.gittins@amaysim.com.au"
+LABEL maintainer="CloudEng"
 
 COPY ./files/bin/* /usr/local/bin/
 


### PR DESCRIPTION
Breaking changes were introduced after version 0.87.6 that causes a lot of errors for existing files. Chose to pin the version rather than adding all of these new error codes to the linting config file:

  - E3688
  - E1019
  - E2533
  - E1022
  - E3031
  - E3512
  - E3002
  - E3045
  - E3009
  - E3690
  - E3691
  - E1020
  - E3011
  - E3045
  - E3014
  - E3005
  - W3011
  - W2001
  - W3045
  - W2531
  - W3687
  - W1011
  - W2001
  - W3687
  - W2010